### PR TITLE
replace talloc with ralloc

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ aware and depend on particular entries in those models.
 - openssl
 - expat
 - libev (including the event.h compatibility header, libev-libevent-dev package on Debian/Ubuntu)
-- libtalloc
+- libralloc
 - lua 5.1
 - lua-event
 - xsltproc

--- a/configure.ac
+++ b/configure.ac
@@ -103,8 +103,8 @@ AC_CHECK_LIB([lua], lua_callk, , [have_liblua=no], [-ldl -lm])
 if test x$have_liblua = xno; then
    AC_CHECK_LIB([lua5.1], lua_call, , AC_MSG_ERROR(Required liblua missing), [-ldl -lm])
 fi
-AC_CHECK_LIB(talloc, talloc_named_const, , AC_MSG_ERROR(Required libtalloc missing) )
-AC_CHECK_HEADERS([talloc.h talloc/talloc.h])
+AC_CHECK_LIB(ralloc, ralloc_context, , AC_MSG_ERROR(Required libralloc missing) )
+AC_CHECK_HEADERS([ralloc.h])
 
 save_LIBS=$LIBS
 

--- a/libdmconfig/debug.c
+++ b/libdmconfig/debug.c
@@ -17,11 +17,7 @@
 #include <inttypes.h>
 #include <arpa/inet.h>
 
-#ifdef HAVE_TALLOC_TALLOC_H
-# include <talloc/talloc.h>
-#else
-# include <talloc.h>
-#endif
+#include <ralloc.h>
 
 #include "errors.h"
 #include "dmmsg.h"

--- a/libdmconfig/dm_dmclient_rpc_skel.c
+++ b/libdmconfig/dm_dmclient_rpc_skel.c
@@ -18,11 +18,7 @@
 #include "libdmconfig/debug.h"
 #endif
 
-#ifdef HAVE_TALLOC_TALLOC_H
-# include <talloc/talloc.h>
-#else
-# include <talloc.h>
-#endif
+#include <ralloc.h>
 
 #include "libdmconfig/dmmsg.h"
 #include "libdmconfig/dmconfig.h"
@@ -117,7 +113,7 @@ rpc_agent_set_boot_order_skel(void *ctx, DM2_AVPGRP *obj)
 	pcnt = 0;
 	do {
 		if ((pcnt % BLOCK_ALLOC) == 0)
-			if (!(boot_order = talloc_realloc(NULL, boot_order, char *, pcnt + BLOCK_ALLOC)))
+			if (!(boot_order = reralloc(NULL, boot_order, char *, pcnt + BLOCK_ALLOC)))
 				return RC_ERR_ALLOC;
 
 		if ((rc = dm_expect_string_type(obj, AVP_STRING, VP_TRAVELPING, &boot_order[pcnt])) != RC_OK)
@@ -128,7 +124,7 @@ rpc_agent_set_boot_order_skel(void *ctx, DM2_AVPGRP *obj)
 	if (rc == RC_OK)
 		rc = rpc_agent_set_boot_order(ctx, pcnt, (const char **)boot_order);
 
-	talloc_free(boot_order);
+	ralloc_free(boot_order);
 	return rc;
 }
 

--- a/libdmconfig/dm_dmclient_rpc_stub.c
+++ b/libdmconfig/dm_dmclient_rpc_stub.c
@@ -15,11 +15,7 @@
 #include "libdmconfig/debug.h"
 #endif
 
-#ifdef HAVE_TALLOC_TALLOC_H
-# include <talloc/talloc.h>
-#else
-# include <talloc.h>
-#endif
+#include <ralloc.h>
 
 #include "libdmconfig/dmmsg.h"
 #include "libdmconfig/dmconfig.h"

--- a/libdmconfig/dm_dmconfig_rpc_skel.c
+++ b/libdmconfig/dm_dmconfig_rpc_skel.c
@@ -19,11 +19,7 @@
 #include "libdmconfig/debug.h"
 #endif
 
-#ifdef HAVE_TALLOC_TALLOC_H
-# include <talloc/talloc.h>
-#else
-# include <talloc.h>
-#endif
+#include <ralloc.h>
 
 #include "libdmconfig/dmmsg.h"
 #include "libdmconfig/dmconfig.h"
@@ -47,7 +43,7 @@ dm_expect_path_type(DM2_AVPGRP *grp, uint32_t exp_code, uint32_t exp_vendor_id, 
 	if (!dm_name2sel(s, value))
 		r = RC_ERR_MISC;
 
-	talloc_free(s);
+	ralloc_free(s);
 	return r;
 }
 
@@ -154,7 +150,7 @@ rpc_param_notify_skel(void *ctx, DM2_AVPGRP *obj, DM2_REQUEST *answer)
 	pcnt = 0;
 	do {
 		if ((pcnt % BLOCK_ALLOC) == 0)
-			if (!(path = talloc_realloc(NULL, path, dm_selector, pcnt + BLOCK_ALLOC)))
+			if (!(path = reralloc(NULL, path, dm_selector, pcnt + BLOCK_ALLOC)))
 				return RC_ERR_ALLOC;
 
 		if ((rc = dm_expect_path_type(&grp, AVP_PATH, VP_TRAVELPING, &path[pcnt])) != RC_OK)
@@ -165,7 +161,7 @@ rpc_param_notify_skel(void *ctx, DM2_AVPGRP *obj, DM2_REQUEST *answer)
 	if (rc == RC_OK)
 		rc = rpc_param_notify(ctx, notify, pcnt, path, answer);
 
-	talloc_free(path);
+	ralloc_free(path);
 	return rc;
 }
 
@@ -233,7 +229,7 @@ rpc_db_set_skel(void *ctx, DM2_AVPGRP *obj, DM2_REQUEST *answer)
 		DM2_AVPGRP grp;
 
 		if ((pvcnt % BLOCK_ALLOC) == 0)
-			if (!(values = talloc_realloc(NULL, values, struct rpc_db_set_path_value, pvcnt + BLOCK_ALLOC)))
+			if (!(values = reralloc(NULL, values, struct rpc_db_set_path_value, pvcnt + BLOCK_ALLOC)))
 				return RC_ERR_ALLOC;
 
 		if ((rc = dm_expect_object(obj, &grp)) != RC_OK
@@ -247,7 +243,7 @@ rpc_db_set_skel(void *ctx, DM2_AVPGRP *obj, DM2_REQUEST *answer)
 
 	rc = rpc_db_set(ctx, pvcnt, values, answer);
 
-	talloc_free(values);
+	ralloc_free(values);
 	return rc;
 }
 
@@ -261,7 +257,7 @@ rpc_db_get_skel(void *ctx, DM2_AVPGRP *obj, DM2_REQUEST *answer)
 	pcnt = 0;
 	do {
 		if ((pcnt % BLOCK_ALLOC) == 0)
-			if (!(values = talloc_realloc(NULL, values, dm_selector, pcnt + BLOCK_ALLOC)))
+			if (!(values = reralloc(NULL, values, dm_selector, pcnt + BLOCK_ALLOC)))
 				return RC_ERR_ALLOC;
 
 		if ((rc = dm_expect_path_type(obj, AVP_PATH, VP_TRAVELPING, values + pcnt)) != RC_OK)
@@ -273,7 +269,7 @@ rpc_db_get_skel(void *ctx, DM2_AVPGRP *obj, DM2_REQUEST *answer)
 	if (rc == RC_OK)
 		rc = rpc_db_get(ctx, pcnt, values, answer);
 
-	talloc_free(values);
+	ralloc_free(values);
 	return rc;
 }
 
@@ -455,7 +451,7 @@ rpc_set_boot_order_skel(void *ctx, DM2_AVPGRP *obj)
 	pcnt = 0;
 	do {
 		if ((pcnt % BLOCK_ALLOC) == 0)
-			if (!(boot_order = talloc_realloc(NULL, boot_order, char *, pcnt + BLOCK_ALLOC)))
+			if (!(boot_order = reralloc(NULL, boot_order, char *, pcnt + BLOCK_ALLOC)))
 				return RC_ERR_ALLOC;
 
 		if ((rc = dm_expect_string_type(obj, AVP_STRING, VP_TRAVELPING, &boot_order[pcnt])) != RC_OK)
@@ -466,7 +462,7 @@ rpc_set_boot_order_skel(void *ctx, DM2_AVPGRP *obj)
 	if (rc == RC_OK)
 		rc = rpc_set_boot_order(ctx, pcnt, (const char **)boot_order);
 
-	talloc_free(boot_order);
+	ralloc_free(boot_order);
 	return rc;
 }
 

--- a/libdmconfig/dm_dmconfig_rpc_stub.c
+++ b/libdmconfig/dm_dmconfig_rpc_stub.c
@@ -15,11 +15,7 @@
 #include "libdmconfig/debug.h"
 #endif
 
-#ifdef HAVE_TALLOC_TALLOC_H
-# include <talloc/talloc.h>
-#else
-# include <talloc.h>
-#endif
+#include <ralloc.h>
 
 #include "libdmconfig/dmmsg.h"
 #include "libdmconfig/dmcontext.h"

--- a/libdmconfig/dmconfig.c
+++ b/libdmconfig/dmconfig.c
@@ -37,11 +37,7 @@
 #include "debug.h"
 #endif
 
-#ifdef HAVE_TALLOC_TALLOC_H
-# include <talloc/talloc.h>
-#else
-# include <talloc.h>
-#endif
+#include <ralloc.h>
 
 #include "mand/dm_token.h"
 #include "mand/dm_strings.h"
@@ -248,7 +244,7 @@ uint32_t dm_expect_string_type(DM2_AVPGRP *grp, uint32_t exp_code, uint32_t exp_
 	if ((r = dm_expect_raw(grp, exp_code, exp_vendor_id, &data, &size)) != RC_OK)
 		return r;
 
-	if (!(*value = talloc_strndup(grp->ctx, data, size)))
+	if (!(*value = ralloc_strndup(grp->ctx, data, size)))
 		return RC_ERR_ALLOC;
 
 	return RC_OK;
@@ -418,11 +414,11 @@ DM2_REQUEST *dm_new_request(void *ctx, uint32_t code, uint8_t flags, uint32_t ho
 {
 	DM2_REQUEST *req;
 
-	if (!(req = talloc_zero(ctx, DM2_REQUEST)))
+	if (!(req = rzalloc(ctx, DM2_REQUEST)))
 		return NULL;
 
 	if (dm_new_packet(ctx, req, code, flags, APP_ID, hopid, endid) != RC_OK) {
-		talloc_free(req);
+		ralloc_free(req);
 		return NULL;
 	}
 

--- a/libdmconfig/dmconfig.h
+++ b/libdmconfig/dmconfig.h
@@ -22,11 +22,7 @@
 #include <sys/queue.h>
 #include <ev.h>
 
-#ifdef HAVE_TALLOC_TALLOC_H
-# include <talloc/talloc.h>
-#else
-# include <talloc.h>
-#endif
+#include <ralloc.h>
 
 #include "dmmsg.h"
 #include "libdmconfig/codes.h"

--- a/libdmconfig/dmmsg.c
+++ b/libdmconfig/dmmsg.c
@@ -19,11 +19,7 @@
 
 #include "debug.h"
 
-#ifdef HAVE_TALLOC_TALLOC_H
-# include <talloc/talloc.h>
-#else
-# include <talloc.h>
-#endif
+#include <ralloc.h>
 
 #include "errors.h"
 #include "codes.h"
@@ -54,7 +50,7 @@ DM2_AVPGRP *dm_new_avpgrp(void *ctx)
 {
 	DM2_AVPGRP *grp;
 
-	if (!(grp = talloc_zero(ctx, DM2_AVPGRP)))
+	if (!(grp = rzalloc(ctx, DM2_AVPGRP)))
 		return NULL;
 	grp->ctx = grp;
 
@@ -63,19 +59,19 @@ DM2_AVPGRP *dm_new_avpgrp(void *ctx)
 
 void dm_free_avpgrp(DM2_AVPGRP *grp)
 {
-	talloc_free(grp);
+	ralloc_free(grp);
 }
 
 void dm_initialize_avpgrp(void *ctx, DM2_AVPGRP *grp)
 {
 	if (!ctx)
-		ctx = talloc_new(NULL);
+		ctx = ralloc_context(NULL);
 	grp->ctx = ctx;
 }
 
 void dm_release_avpgrp(DM2_AVPGRP *grp)
 {
-	talloc_free(grp->ctx);
+	ralloc_free(grp->ctx);
 }
 
 /* decoder functions */
@@ -104,7 +100,7 @@ dm_copy_avpgrp(DM2_AVPGRP *dest, DM2_AVPGRP *src)
 	assert(dest);
 	assert(src);
 
-	if (!(dest->data = talloc_memdup(dest->ctx, src->data, src->size)))
+	if (!(dest->data = ralloc_memdup(dest->ctx, src->data, src->size)))
 	      return RC_ERR_ALLOC;
 
 	dest->size = src->size;
@@ -164,7 +160,7 @@ dm_new_packet(void *ctx, DM2_REQUEST *req, uint32_t code, uint8_t flags, uint32_
 
 	memset(req, 0, sizeof(DM2_REQUEST));
 
-	if (!(req->packet = pkt = talloc_zero_size(ctx, DM_BLOCK_ALLOC)))
+	if (!(req->packet = pkt = rzalloc_size(ctx, DM_BLOCK_ALLOC)))
 		return RC_ERR_ALLOC;
 
 	pkt->version = 1;
@@ -231,7 +227,7 @@ dm_packet_ensure_space(DM2_REQUEST *req, size_t len)
 	if (have == want)
 		return RC_OK;
 
-	if (!(req->packet = talloc_realloc_size(NULL, req->packet, want * DM_BLOCK_ALLOC)))
+	if (!(req->packet = reralloc_size(NULL, req->packet, want * DM_BLOCK_ALLOC)))
 		return RC_ERR_ALLOC;
 	memset((unsigned char *)req->packet + (have * DM_BLOCK_ALLOC), 0, (want - have) * DM_BLOCK_ALLOC);
 

--- a/libdmconfig/dmmsg.h
+++ b/libdmconfig/dmmsg.h
@@ -19,11 +19,7 @@
 #include <string.h>
 #include <sys/queue.h>
 
-#ifdef HAVE_TALLOC_TALLOC_H
-# include <talloc/talloc.h>
-#else
-# include <talloc.h>
-#endif
+#include <ralloc.h>
 
 #include "libdmconfig/codes.h"
 
@@ -82,7 +78,7 @@ typedef struct dm2_avpgrp {
 	size_t pos;
 } DM2_AVPGRP;
 
-#define DM2_AVPGRP_INITIALIZER {talloc_new(NULL), NULL, 0, 0}
+#define DM2_AVPGRP_INITIALIZER {ralloc_context(NULL), NULL, 0, 0}
 
 typedef struct dm2_request {
 	struct {

--- a/libdmconfig/tests/dm_sample.c
+++ b/libdmconfig/tests/dm_sample.c
@@ -15,11 +15,7 @@
 #include <arpa/inet.h>
 #include <string.h>
 
-#ifdef HAVE_TALLOC_TALLOC_H
-# include <talloc/talloc.h>
-#else
-# include <talloc.h>
-#endif
+#include <ralloc.h>
 
 #include <libdmconfig/dmmsg.h>
 #include <libdmconfig/debug.h>
@@ -47,7 +43,7 @@ main(int argc __attribute__((unused)), char **argv __attribute__((unused))) {
 		return 1;
 	if(!(grp = new_dm_avpgrp(req)) ||
 	   !(buf1 = malloc(size1 = strlen(p1) + 4)) ||!(buf2 = malloc(size2 = strlen(p2) + 4))) {
-		talloc_free(req);
+		ralloc_free(req);
 		return 1;
 	}
 	*(uint32_t*)buf1 = *(uint32_t*)buf2 = htonl(AVP_STRING);
@@ -61,24 +57,24 @@ main(int argc __attribute__((unused)), char **argv __attribute__((unused))) {
 
 	dump_dm_packet(req);
 
-	talloc_free(req);
+	ralloc_free(req);
 
 			/* SET command */
 
 	if(!(req = new_dm_request(NULL, CMD_DB_SET, CMD_FLAG_REQUEST, APP_ID, hop2hop, end2end)))
 		return 1;
 	if(!(grp = new_dm_avpgrp(req)) || !(pair = new_dm_avpgrp(grp))) {
-		talloc_free(req);
+		ralloc_free(req);
 		return 1;
 	}
 
 	dm_avpgrp_add_string(grp, &pair, AVP_PATH, 0, VP_TRAVELPING, p1);
 	dm_avpgrp_add_string(grp, &pair, AVP_STRING, 0, VP_TRAVELPING, "test value for ManufacturerOUI");
 	dm_avpgrp_add_avpgrp(req, &grp, AVP_CONTAINER, 0, VP_TRAVELPING, pair);
-	talloc_free(pair);
+	ralloc_free(pair);
 
 	if(!(pair = new_dm_avpgrp(grp))) {
-		talloc_free(req);
+		ralloc_free(req);
 		return 1;
 	}
 	dm_avpgrp_add_string(grp, &pair, AVP_PATH, 0, VP_TRAVELPING, p2);
@@ -88,7 +84,7 @@ main(int argc __attribute__((unused)), char **argv __attribute__((unused))) {
 
 	dump_dm_packet(req);
 
-	talloc_free(req);
+	ralloc_free(req);
 
 	return 0;
 }

--- a/mand/dm_action.c
+++ b/mand/dm_action.c
@@ -8,11 +8,7 @@
 
 #include <stdlib.h>
 
-#ifdef HAVE_TALLOC_TALLOC_H
-# include <talloc/talloc.h>
-#else
-# include <talloc.h>
-#endif
+#include <ralloc.h>
 
 #include <sys/tree.h>
 
@@ -79,7 +75,7 @@ static void insert_action(enum dm_actions action, const dm_selector sel, enum dm
 	struct exec_node *node;
 	struct exec_node *res;
 
-	node = talloc_zero(exec_chain, struct exec_node);
+	node = rzalloc(exec_chain, struct exec_node);
 	if (!node)
 		return;
 
@@ -94,7 +90,7 @@ static void insert_action(enum dm_actions action, const dm_selector sel, enum dm
 	res = RB_INSERT(action_tree, exec_chain, node);
 	if (res != NULL) {
 		debug(": duplicate insert");
-		talloc_free(node);
+		ralloc_free(node);
 	}
 
 }
@@ -105,7 +101,7 @@ void action_sel(enum dm_actions action, const dm_selector sel, enum dm_action_ty
 		return;
 
 	if (!exec_chain)
-		exec_chain = talloc_zero(NULL, struct action_tree);
+		exec_chain = rzalloc(NULL, struct action_tree);
 	if (!exec_chain)
 		return;
 
@@ -181,6 +177,6 @@ void exec_actions(void)
 
 void clear_actions(void)
 {
-	talloc_free(exec_chain);
+	ralloc_free(exec_chain);
 	exec_chain = NULL;
 }

--- a/mand/dm_dmconfig.c
+++ b/mand/dm_dmconfig.c
@@ -45,11 +45,7 @@
 #include "libdmconfig/debug.h"
 #endif
 
-#ifdef HAVE_TALLOC_TALLOC_H
-# include <talloc/talloc.h>
-#else
-# include <talloc.h>
-#endif
+#include <ralloc.h>
 
 #include "libdmconfig/dmconfig.h"
 #include "libdmconfig/dmcontext.h"
@@ -111,7 +107,7 @@ end_session(SOCKCONTEXT *ctx)
 	}
 
 	TAILQ_REMOVE(&socket_head, ctx, list);
-	talloc_free(ctx);
+	ralloc_free(ctx);
 
 	exec_actions_pre();
 	exec_actions();
@@ -146,7 +142,7 @@ accept_cb(DMCONFIG_EVENT event, DMCONTEXT *socket, void *userdata)
 		return RC_OK;
 	}
 
-	if (!(ctx = talloc_zero(NULL, SOCKCONTEXT)))
+	if (!(ctx = rzalloc(NULL, SOCKCONTEXT)))
 		return RC_ERR_ALLOC;
 
 	dm_context_set_userdata(socket, ctx);
@@ -1515,7 +1511,7 @@ uint32_t rpc_register_role(void *data, const char *role)
 		return RC_ERR_MISC;
 
 	/* add role */
-	ctx->role = talloc_strdup(ctx, role);
+	ctx->role = ralloc_strdup(ctx, role);
 	dm_debug(ctx->id, "CMD: %s %s: success", "REGISTER_ROLE", role);
 
 	return RC_OK;

--- a/mand/dmctrl.c
+++ b/mand/dmctrl.c
@@ -79,7 +79,7 @@ decode_node_list(const char *prefix, DM2_AVPGRP *grp, DECODE_CB cb, void *cb_dat
 		if ((r = dm_expect_string_type(&container, AVP_NAME, VP_TRAVELPING, &name)) != RC_OK)
 			return r;
 
-		if (!(path = talloc_asprintf(container.ctx, "%s.%s", prefix, name)))
+		if (!(path = ralloc_asprintf(container.ctx, "%s.%s", prefix, name)))
 			return RC_ERR_ALLOC;
 
 		while (decode_node_list(path, &container, cb, cb_data) == RC_OK) {
@@ -91,7 +91,7 @@ decode_node_list(const char *prefix, DM2_AVPGRP *grp, DECODE_CB cb, void *cb_dat
 		if ((r = dm_expect_uint16_type(&container, AVP_NAME, VP_TRAVELPING, &id)) != RC_OK)
 			return r;
 
-		if (!(path = talloc_asprintf(container.ctx, "%s.%d", prefix, id)))
+		if (!(path = ralloc_asprintf(container.ctx, "%s.%d", prefix, id)))
 			return RC_ERR_ALLOC;
 
 		while (decode_node_list(path, &container, cb, cb_data) == RC_OK) {
@@ -103,7 +103,7 @@ decode_node_list(const char *prefix, DM2_AVPGRP *grp, DECODE_CB cb, void *cb_dat
 		if ((r = dm_expect_string_type(&container, AVP_NAME, VP_TRAVELPING, &name)) != RC_OK)
 			return r;
 
-		if (!(path = talloc_asprintf(container.ctx, "%s.%s", prefix, name)))
+		if (!(path = ralloc_asprintf(container.ctx, "%s.%s", prefix, name)))
 			return RC_ERR_ALLOC;
 
 		while (decode_node_list(path, &container, cb, cb_data) == RC_OK) {
@@ -116,7 +116,7 @@ decode_node_list(const char *prefix, DM2_AVPGRP *grp, DECODE_CB cb, void *cb_dat
 		    || (r = dm_expect_uint32_type(&container, AVP_TYPE, VP_TRAVELPING, &type)) != RC_OK)
 			return r;
 
-		if (!(path = talloc_asprintf(container.ctx, "%s.%s", prefix, name)))
+		if (!(path = ralloc_asprintf(container.ctx, "%s.%s", prefix, name)))
 			return RC_ERR_ALLOC;
 
 		if ((r = dm_expect_avp(&container, &code, &vendor_id, &data, &size)) != RC_OK)
@@ -130,7 +130,7 @@ decode_node_list(const char *prefix, DM2_AVPGRP *grp, DECODE_CB cb, void *cb_dat
 		    || (r = dm_expect_uint32_type(&container, AVP_TYPE, VP_TRAVELPING, &type)) != RC_OK)
 			return r;
 
-		if (!(path = talloc_asprintf(container.ctx, "%s.%s", prefix, name)))
+		if (!(path = ralloc_asprintf(container.ctx, "%s.%s", prefix, name)))
 			return RC_ERR_ALLOC;
 
 		while (dm_expect_group_end(&container) != RC_OK) {
@@ -278,7 +278,7 @@ uint32_t dmctrl_connect_cb(DMCONFIG_EVENT event, DMCONTEXT *socket, void *userda
 				break;
 
 			printf("%s", dump);
-			talloc_free(dump);
+			ralloc_free(dump);
 
 			break;
 		}


### PR DESCRIPTION
Replace all talloc usage with ralloc from Mesa project. Ralloc is a
lightweight replacement for talloc under MIT license. This removes
the GPLv3 requirement and allows using MAND again under MPL 2.0 or
GPLv2.

This depends on https://github.com/opencpe/openwrt-packages/pull/4

Signed-off-by: Jonas Gorski jogo@openwrt.org
