### PR TITLE
Yang translator and dmconfig fixes

### DIFF
--- a/mand/dm_dmconfig.c
+++ b/mand/dm_dmconfig.c
@@ -698,6 +698,7 @@ dmconfig_set_array_cb(SOCKCONTEXT *ctx __attribute__((unused)),
 		while (rem) {
 			size_t s_len;
 			struct dm_instance_node *node;
+			DM_VALUE *value;
 
 			p = memchr(s, ',', rem);
 			s_len = (p != NULL) ? (size_t)(p - s) : rem;
@@ -705,8 +706,13 @@ dmconfig_set_array_cb(SOCKCONTEXT *ctx __attribute__((unused)),
 			if (!(node = dm_add_instance_by_selector(sel, &id)))
 				return RC_ERR_ALLOC;
 
-			if ((rc = dmconfig_string2value(s, s_len, &elem->u.t.table->table[0], dm_get_value_ref_by_index(DM_TABLE(node->table), 0))) != DM_OK)
+			value = dm_get_value_ref_by_index(DM_TABLE(node->table), 0);
+
+			if ((rc = dmconfig_string2value(s, s_len, &elem->u.t.table->table[0], value)) != DM_OK)
 				return rc;
+
+			value->flags |= DV_UPDATED;
+			DM_parity_update(*value);
 
 			update_instance_node_index(node);
 
@@ -725,6 +731,7 @@ dmconfig_set_array_cb(SOCKCONTEXT *ctx __attribute__((unused)),
 		while (dm_expect_group_end(&container) != RC_OK) {
 			struct dm2_avp a;
 			struct dm_instance_node *node;
+			DM_VALUE *value;
 
 			if ((rc = dm_expect_value(&container, &a)) != RC_OK)
 				return rc;
@@ -732,8 +739,13 @@ dmconfig_set_array_cb(SOCKCONTEXT *ctx __attribute__((unused)),
 			if (!(node = dm_add_instance_by_selector(sel, &id)))
 				return RC_ERR_ALLOC;
 
-			if ((rc = dmconfig_avp2value(&a, &elem->u.t.table->table[0], dm_get_value_ref_by_index(DM_TABLE(node->table), 0))) != DM_OK)
+			value = dm_get_value_ref_by_index(DM_TABLE(node->table), 0);
+
+			if ((rc = dmconfig_avp2value(&a, &elem->u.t.table->table[0], value)) != DM_OK)
 				return rc;
+
+			value->flags |= DV_UPDATED;
+			DM_parity_update(*value);
 
 			update_instance_node_index(node);
 

--- a/yang/pyang_plugin/OpenCPE.py
+++ b/yang/pyang_plugin/OpenCPE.py
@@ -149,8 +149,8 @@ def emit_tree(modules, fd):
 
 #GLOBAL SETTINGS
 #mapping of the yang types to c types
-c_types = {'string':'T_STR', 'enumeration':'T_ENUM', 'uint8':'T_UINT', 'uint16':'T_UINT', 'uint32':'T_UINT', 'uint64':'T_UINT',
-           'int8':'T_INT', 'int16':'T_INT', 'int32':'T_INT', 'int64':'T_INT', 'boolean':'T_BOOL', 'bits':'T_BINARY',
+c_types = {'string':'T_STR', 'enumeration':'T_ENUM', 'uint8':'T_UINT', 'uint16':'T_UINT', 'uint32':'T_UINT', 'uint64':'T_UINT64',
+           'int8':'T_INT', 'int16':'T_INT', 'int32':'T_INT', 'int64':'T_INT64', 'boolean':'T_BOOL', 'bits':'T_BINARY',
            'binary':'T_BASE64', 'identityref':'T_STR', 'leafref':'T_SELECTOR', 'inet:ipv4-address':'T_IPADDR4', 'inet:ipv6-address':'T_IPADDR6',
             'empty':'T_BOOL', 'inet:host':'T_STR', 'inet:ip-address':'T_STR', 'yang:date-and-time':'T_TICKS'}
 

--- a/yang/pyang_plugin/OpenCPE.py
+++ b/yang/pyang_plugin/OpenCPE.py
@@ -226,7 +226,8 @@ def print_node(s, module, typedefs, groupings, augments, deviations, annotations
             fd.write(tab + ".idx = {\n")
             fd.write(2*tab + "{ .flags = IDX_UNIQUE, .type = T_INSTANCE },\n")
             for key in keys:
-                fd.write(2*tab + "{ .flags = IDX_UNIQUE, .type = " + c_types[key_leafs[key.arg]] + ", .element = " + "field_" + name + "_" + key.arg + " },\n")
+                fd.write(2*tab + "{ .flags = IDX_UNIQUE, .type = " + c_types[key_leafs[key.arg]] +
+                         ", .element = " + "field_" + name + "_" + make_key(key, keep_hyphens=False) + " },\n")
             fd.write(tab + "},\n")
             fd.write(tab + ".size = " + str(len(keys)+1) + "\n")
             fd.write("};\n")


### PR DESCRIPTION
 * mand has T_INT64 and T_UINT64, so there is no need to map them to
   the 32-bit T_INT and T_UINT types.